### PR TITLE
Set recognizer's culture and default device

### DIFF
--- a/View/NoteWindow.xaml.cs
+++ b/View/NoteWindow.xaml.cs
@@ -35,7 +35,8 @@ namespace NotesApp.View
             // I tried an alternative which returned "en-AU" for my computer but this also crashed.
             var currentCulture = System.Globalization.CultureInfo.CurrentCulture;
 
-                recognizer = new SpeechRecognitionEngine();
+                recognizer = new SpeechRecognitionEngine(new System.Globalization.CultureInfo("en-US"));
+            recognizer.SetInputToDefaultAudioDevice();
 
             //When I left the SpeechRecognitionEngine as blank / default, it then crashed on the next line.
 

--- a/ViewModel/NoteVM.cs
+++ b/ViewModel/NoteVM.cs
@@ -65,6 +65,7 @@ namespace NotesApp.ViewModel
 		{
 			using (SQLite.SQLiteConnection conn = new SQLite.SQLiteConnection(DatabaseHelper.dbFile))
 			{
+				conn.CreateTable<Notebook>();
 				var notebooks = conn.Table<Notebook>().ToList();
 				Notebooks.Clear();
 				foreach(var notebook in notebooks)


### PR DESCRIPTION
This couple of changes seem to make the recognizer work. When the `recognized` method is called, the string is created correctly and everything, the only thing missing is adding that to the note, but it seems that functionality is missing?